### PR TITLE
Fix unpacking negative temperature

### DIFF
--- a/custom_components/thermoplus_ble/sensor.py
+++ b/custom_components/thermoplus_ble/sensor.py
@@ -143,7 +143,7 @@ class Processor:
       if len(value) != 19:
         continue
       Payload = namedtuple('Payload', 'battery temperature humidity')
-      payload = Payload._make(struct.unpack('<HHH', value[10:16]))
+      payload = Payload._make(struct.unpack('<HhH', value[10:16]))
       return {
         "mac": data.get('mac'),
         "rssi": data.get('rssi'),


### PR DESCRIPTION
I fixed issue #9  myself
The temperature got unpacked as an unsigned short. This needs to be a signed short because temperatures can be negative.